### PR TITLE
Support for message forwarding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Sergey Sova <mail@sergeysova.com>"]
 edition = "2018"
 
 [dependencies]
-reqwest = "=0.8.6"
+reqwest = "=0.9.9"
 env_logger = "0.5.12"
 select = "0.4.2"
 dotenv = "0.13.0"

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -49,6 +49,35 @@ impl Bot {
 
         self.send("sendMessage", &body)
     }
+
+    pub fn forward_message(
+        &self,
+        from_chat_id: String,
+        chat_id: String,
+        message_id: usize,
+    ) -> ReqwestResult {
+        let body = ForwardMessage {
+            from_chat_id,
+            chat_id,
+            message_id,
+        };
+
+        self.send("sendMessage", &body)
+    }
+
+    pub fn response_id(mut res: reqwest::Response) -> Option<usize> {
+        res.text()
+            .ok()
+            .and_then(|text| serde_json::from_str(&text).ok())
+            .map(|msg: Message| msg.message_id)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct Message {
+    message_id: usize,
+    // the rest fields are unused and might be extended based on:
+    // https://core.telegram.org/bots/api#message
 }
 
 #[derive(Debug, Serialize)]
@@ -57,6 +86,13 @@ struct SendMessage {
     text: String,
     parse_mode: String,
     disable_web_page_preview: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ForwardMessage {
+    chat_id: String,
+    from_chat_id: String,
+    message_id: usize,
 }
 
 impl Default for SendMessage {

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -1,5 +1,5 @@
-use hyper::header::{ContentLength, ContentType};
 use reqwest;
+use reqwest::header::{HeaderValue, CONTENT_LENGTH, CONTENT_TYPE};
 use reqwest::Url;
 use serde::Serialize;
 use serde_json;
@@ -28,15 +28,15 @@ impl Bot {
         );
 
         let href = Url::parse(url.as_str()).unwrap();
-        let mut req = reqwest::Client::new().post(href);
+        let req = reqwest::Client::new().post(href);
         let content = serde_json::to_string(&body).unwrap();
         let content_len = content.len();
 
         // Because, req.json(&body) sends noise instead of JSON
-        req.body(content);
-        req.header(ContentType::json());
-        req.header(ContentLength(content_len as u64));
-        req.send()
+        req.body(content)
+            .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
+            .header(CONTENT_LENGTH, HeaderValue::from(content_len))
+            .send()
     }
 
     pub fn send_message(&self, chat_id: String, text: String) -> ReqwestResult {


### PR DESCRIPTION
Chat ids for forwarding to is defined by `FORWARD_ID` environment variable. That can be a list separated by `:`