### PR TITLE
fix parsing to support new TWIR article structure

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ fn main() -> Result<(), Error> {
 
             let mut _res = bot.send_message(chat_id.clone(), article.core_updates())?;
 
-            let mut _res = bot.send_message(chat_id.clone(), article.news())?;
+            let mut _res = bot.send_message(chat_id.clone(), article.community_updates())?;
 
             let mut _res = bot.send_message(chat_id.clone(), article.crate_of_week())?;
 


### PR DESCRIPTION
TWIR has extended their `News` section, and now it includes several subtopics and is called `Community Updates`.

This PR fixes the parsing module in accordance to this change.